### PR TITLE
Added new symlinks for PinePhone stuff

### DIFF
--- a/Obsidian/apps/96/com.github.bilelmoussaoui.Authenticator.svg
+++ b/Obsidian/apps/96/com.github.bilelmoussaoui.Authenticator.svg
@@ -1,0 +1,1 @@
+passwords.svg

--- a/Obsidian/apps/96/nl.brixit.powersupply.svg
+++ b/Obsidian/apps/96/nl.brixit.powersupply.svg
@@ -1,0 +1,1 @@
+gnome-power-manager.svg

--- a/Obsidian/apps/96/org.gnome.Podcasts.svg
+++ b/Obsidian/apps/96/org.gnome.Podcasts.svg
@@ -1,0 +1,1 @@
+podcast.svg

--- a/Obsidian/apps/96/org.gnome.zbrown.KingsCross.Generic.svg
+++ b/Obsidian/apps/96/org.gnome.zbrown.KingsCross.Generic.svg
@@ -1,0 +1,1 @@
+gnome-terminal.svg

--- a/Obsidian/apps/96/org.gnome.zbrown.KingsCross.Generic.svg
+++ b/Obsidian/apps/96/org.gnome.zbrown.KingsCross.Generic.svg
@@ -1,1 +1,1 @@
-gnome-terminal.svg
+utilities-terminal.svg

--- a/Obsidian/apps/96/org.postmarketos.Megapixels.svg
+++ b/Obsidian/apps/96/org.postmarketos.Megapixels.svg
@@ -1,0 +1,1 @@
+accessories-camera.svg

--- a/Obsidian/apps/96/sm.puri.Calls.svg
+++ b/Obsidian/apps/96/sm.puri.Calls.svg
@@ -1,0 +1,1 @@
+linphone.svg

--- a/Obsidian/apps/96/sm.puri.Calls.svg
+++ b/Obsidian/apps/96/sm.puri.Calls.svg
@@ -1,1 +1,1 @@
-linphone.svg
+internet-telephony.svg

--- a/Obsidian/apps/96/sm.puri.Chatty.svg
+++ b/Obsidian/apps/96/sm.puri.Chatty.svg
@@ -1,0 +1,1 @@
+xchat.svg


### PR DESCRIPTION
I recently got myself a PinePhone and managed to change the icon theme to Obsidian

There were some programs pre-installed that were missing icons, so I symlinked some existing icons for them, mainly as placeholders.

* `sm.puri.Calls` is practically call history.
* `sm.puri.Chatty` is for sending and receiving SMSes.
* `com.github.bilelmoussaoui.Authenticator` is a 2FA code generator.
* `org.gnome.Podcasts` seems to be a podcast listener.
* `nl.brixit.powersupply` displays battery data. 
* `org.gnome.zbrown.KingsCross.Generic.svg` is a minimal terminal.
* `org.postmarketos.Megapixels` is a camera program, like Cheese, but can switch between front and back camera.
